### PR TITLE
v2: sprinkle in strictness

### DIFF
--- a/1brc.cabal
+++ b/1brc.cabal
@@ -62,6 +62,7 @@ common warnings
 
 common extensions
     default-extensions:
+        BangPatterns
         LambdaCase
         NoImplicitPrelude
         OverloadedStrings
@@ -98,6 +99,10 @@ library
     -- Base language which the package is written in.
     default-language: GHC2021
 
+    ghc-options:
+        -O2
+        -funbox-strict-fields
+
 executable 1brc
     -- Import common warning flags.
     import:
@@ -127,6 +132,10 @@ executable 1brc
 
     -- Base language which the package is written in.
     default-language: GHC2021
+
+    ghc-options:
+        -rtsopts
+        -O2
 
 test-suite 1brc-test
     -- Import common warning flags.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Memory: 64 GB
 | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------- | -------------------------------------------------------------------------------------------------- |
 | 0       | Naïve Implementation: Read temperatures into a Map of cities. Iterate serially over each key (station name) in Map to and corresponding list of temperaturs to calculate min, max and mean temperatures. Uses non-performant `String`. | 4714.17 sec    |         | [a58c42d](https://github.com/rhoskal/1brc-haskell/commit/a58c42dcb0b2f414fdfbb1a503777dc42ade1fd2) |
 | 1       | Parser uses `Text` instead of `String`, read file as `ByteString` instead of `String`. Store temperatures as `IntX` instead of `Float`. Ignore rounding due to inconsistencies.                                                        | 1061.41 sec    | 126.49% | [1550352](https://github.com/rhoskal/1brc-haskell/commit/155035264f747254267488c4ea4ea13a7a670538) |
+| 2       | Add strictness and compiler flags for small performance improvements. Read file content lazily.                                                                                                                                        | 969.98 sec     | 9.00%   |                                                                                                    |
 
 ## Development
 
@@ -49,6 +50,12 @@ make build # build and link executable
 hyperfine '1brc -f FILE >/dev/null'
 
 lua verify.lua DIR # verify against all test files
+```
+
+## Profiling
+
+```sh
+1brc +RTS -s -RTS -f FILE >/dev/null
 ```
 
 ## Resources

--- a/lib/Summary.hs
+++ b/lib/Summary.hs
@@ -12,32 +12,32 @@ import RIO.Text qualified as T
 import Text.Printf
 
 data Summary = Summary
-  { sMin :: !Int16,
-    sMax :: !Int16,
-    sTotal :: !Int64,
-    sCount :: !Int32
+  { sMin :: {-# UNPACK #-} !Int16,
+    sMax :: {-# UNPACK #-} !Int16,
+    sTotal :: {-# UNPACK #-} !Int64,
+    sCount :: {-# UNPACK #-} !Int32
   }
   deriving (Show)
 
 mkInitialSummary :: Celsius -> Summary
-mkInitialSummary (Celsius c) = Summary c c (fromIntegral c) 1
+mkInitialSummary (Celsius !c) = Summary c c (fromIntegral c) 1
 
 mergeSummary :: Summary -> Summary -> Summary
-mergeSummary s1 s2 =
-  let sMin' = min (sMin s1) (sMin s2)
-      sMax' = max (sMax s1) (sMax s2)
-      sTotal' = (sTotal s1) + (sTotal s2)
-      sCount' = (sCount s1) + (sCount s2)
+mergeSummary !s1 !s2 =
+  let !sMin' = min (sMin s1) (sMin s2)
+      !sMax' = max (sMax s1) (sMax s2)
+      !sTotal' = (sTotal s1) + (sTotal s2)
+      !sCount' = (sCount s1) + (sCount s2)
    in Summary sMin' sMax' sTotal' sCount'
 
 formatSummary :: Summary -> Text
-formatSummary summary =
+formatSummary !summary =
   let sMin' :: Double
-      sMin' = fromIntegral (sMin summary) / 10.0
+      !sMin' = fromIntegral (sMin summary) / 10.0
 
       sMax' :: Double
-      sMax' = fromIntegral (sMax summary) / 10.0
+      !sMax' = fromIntegral (sMax summary) / 10.0
 
       sMean' :: Double
-      sMean' = ((fromIntegral $ sTotal summary) / (fromIntegral $ sCount summary)) / 10.0
+      !sMean' = ((fromIntegral $ sTotal summary) / (fromIntegral $ sCount summary)) / 10.0
    in T.pack $ printf "%.1f/%.1f/%.1f" sMin' sMean' sMax'


### PR DESCRIPTION
# Overview

- Sprinkle 👨‍🍳 in a little strictness
- Add compiler flags for small performance improvements
- Read file content lazily

## Profiling

After initial profiling, it's clear heap and memory optimizations are up before parallelizing code

```sh
  λ 1brc +RTS -s -RTS -f measurements-10000000.txt >/dev/null

  77,684,942,376 bytes allocated in the heap
     815,888,544 bytes copied during GC
     138,454,864 bytes maximum residency (2 sample(s))
         465,072 bytes maximum slop
             271 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     18592 colls,     0 par    0.306s   0.316s     0.0000s    0.0003s
  Gen  1         2 colls,     0 par    0.001s   0.006s     0.0031s    0.0044s

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    8.979s  (  9.013s elapsed)
  GC      time    0.307s  (  0.322s elapsed)
  EXIT    time    0.001s  (  0.004s elapsed)
  Total   time    9.288s  (  9.340s elapsed)

  %GC     time       0.0%  (0.0% elapsed)

  Alloc rate    8,651,584,863 bytes per MUT second

  Productivity  96.7% of total user, 96.5% of total elapsed
```