### PR TITLE
v4 ditch fancy parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Memory: 64 GB
 |    1    | Parser uses `Text` instead of `String`, read file as `ByteString` instead of `String`. Store temperatures as `IntX` instead of `Float`. Ignore rounding due to inconsistencies.                                                        | 1061.41 sec    | 126.49% | [1550352](https://github.com/rhoskal/1brc-haskell/commit/155035264f747254267488c4ea4ea13a7a670538) |
 |    2    | Add strictness and compiler flags for small performance improvements. Read file content lazily.                                                                                                                                        | 969.98 sec     |   9.00% | [00ddd57](https://github.com/rhoskal/1brc-haskell/commit/00ddd571360f5cd60e90b9a55ab8bb7ed8914f25) |
 |    3    | Replace `State` monad with `List.foldl'`                                                                                                                                                                                               | 970.47 sec     |  -0.05% | [75211bb](https://github.com/rhoskal/1brc-haskell/commit/75211bbd93afc3ec32f1661aa2e3b5b500b184bf) |
+|    4    | Ditch fancy, custom monad `Parser` for a down 'n dirty parser all in the name of speed. 😢                                                                                                                                             | 875.62 sec     |  10.28% |                                                                                                    |
 
 ## Development
 

--- a/lib/Parser.hs
+++ b/lib/Parser.hs
@@ -2,86 +2,12 @@ module Parser
   ( Celsius (..),
     Observation (..),
     Station (..),
-    parser,
+    unsafeParse,
   )
 where
 
-import Control.Applicative (empty)
 import RIO
-import RIO.Char qualified as C
 import RIO.Text qualified as T
-
-newtype Parser a = Parser {runParser :: Text -> Maybe (Text, a)}
-
-instance Functor Parser where
-  fmap :: (a -> b) -> Parser a -> Parser b
-  fmap !fn (Parser !p) = Parser $ \(!input) -> do
-    (!rest, !matched) <- p input
-    return (rest, fn matched)
-
-instance Applicative Parser where
-  pure :: a -> Parser a
-  pure !x = Parser $ \(!input) -> Just (input, x)
-
-  (<*>) :: Parser (a -> b) -> Parser a -> Parser b
-  (Parser !p1) <*> (Parser !p2) = Parser $ \(!input) -> do
-    (!rest, !fn) <- p1 input
-    (!rest', !matched) <- p2 rest
-    return (rest', fn matched)
-
-instance Alternative Parser where
-  empty :: Parser a
-  empty = Parser $ const Nothing
-
-  (<|>) :: Parser a -> Parser a -> Parser a
-  (Parser !p1) <|> (Parser !p2) = Parser $ \(!input) ->
-    p1 input <|> p2 input
-
-instance Monad Parser where
-  (>>=) :: Parser a -> (a -> Parser b) -> Parser b
-  (Parser !p1) >>= fn = Parser $ \(!input) -> do
-    (!rest, !matched) <- p1 input
-    let Parser !p2 = fn matched
-    p2 rest
-
-  return :: a -> Parser a
-  return = pure
-
--- Combinators
-
--- sc :: Parser Text
--- sc = Parser $ \input ->
---   Just (T.dropWhile C.isSpace input, T.empty)
-
-charP :: Char -> Parser Char
-charP !input = Parser fn
-  where
-    fn !txt
-      | T.null txt = Nothing
-      | otherwise =
-          T.uncons txt
-            >>= \(!y, !ys) ->
-              if y == input
-                then Just (ys, input)
-                else Nothing
-
-many1 :: (Char -> Bool) -> Parser Text
-many1 !predicate = Parser $ \(!input) ->
-  let (!matched, !rest) = T.span predicate input
-   in if T.null matched
-        then Nothing
-        else Just (rest, matched)
-
-optionalP :: Parser a -> Parser (Maybe a)
-optionalP (Parser !p) = Parser $ \(!input) ->
-  case p input of
-    Nothing -> Just (input, Nothing)
-    Just (!rest, !matched) -> Just (rest, Just matched)
-
-digitsP :: Parser Text
-digitsP = many1 C.isDigit
-
--- Parsers
 
 newtype Station = Station {unStation :: Text}
   deriving (Eq, Ord, Show)
@@ -95,28 +21,16 @@ data Observation = Observation
   }
   deriving (Eq, Ord, Show)
 
-pStation :: Parser Station
-pStation = Station <$> many1 (/= ';')
-
-pCelsius :: Parser Celsius
-pCelsius = do
-  maybeSign <- optionalP $ charP '-'
-  intPart <- digitsP
-  {- Skip... as if we multiplied by 10 since we know the format is: -?\d?\d.\d -}
-  fracPart <- (charP '.' *> digitsP)
-  let celsiusStr :: Text
-      !celsiusStr =
-        T.concat
-          [ maybe T.empty (const $ T.singleton '-') maybeSign,
-            intPart,
-            fracPart
-          ]
-   in case readMaybe (T.unpack celsiusStr) :: Maybe Int16 of
-        Just !val -> return $ Celsius val
-        Nothing -> empty
-
-pObservation :: Parser Observation
-pObservation = Observation <$> pStation <*> (charP ';' *> pCelsius)
-
-parser :: Text -> Maybe Observation
-parser !input = snd <$> runParser pObservation input
+{- This will result in many false positives:
+ - pass (bad) if the temperature has no fractional part e.g. a whole number
+ - pass (bad) if the temperature has no integer part e.g. `.1`
+ - pass (bad) if no station name is provided but there is still a ';'
+-}
+unsafeParse :: Text -> Maybe Observation
+unsafeParse !line =
+  case T.split (== ';') line of
+    [!station, !celsiusStr] ->
+      fmap
+        (\(!val) -> Observation (Station station) (Celsius val))
+        (readMaybe (T.unpack $ T.filter (/= '.') $ celsiusStr) :: Maybe Int16)
+    _ -> Nothing

--- a/lib/Run.hs
+++ b/lib/Run.hs
@@ -21,7 +21,7 @@ strBuilder !acc =
           <> (T.singleton '=')
           <> (formatSummary summary)
    in T.singleton '{'
-        <> mconcat (List.intersperse (T.singleton ',') (map buildEntry $ Map.toList acc))
+        <> mconcat (List.intersperse (T.pack ", ") (map buildEntry $ Map.toList acc))
         <> T.singleton '}'
         <> T.singleton '\n'
 
@@ -32,7 +32,7 @@ addObservation !acc !o =
    in Map.insertWith mergeSummary station summary acc
 
 parseFile :: Text -> [Observation]
-parseFile = mapMaybe parser . T.lines
+parseFile = mapMaybe unsafeParse . T.lines
 
 run :: RIO App ()
 run = do

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -4,7 +4,7 @@ import Parser
   ( Celsius (..),
     Observation (..),
     Station (..),
-    parser,
+    unsafeParse,
   )
 import RIO
 import RIO.Text qualified as T
@@ -31,13 +31,15 @@ parserSpec = do
 
             input :: Text
             input = stationName <> T.singleton ';' <> celsiusText
-         in case parser input of
+         in case unsafeParse input of
               Just (Observation (Station s) (Celsius c)) ->
                 let maybeCelsius :: Maybe Int16
                     maybeCelsius = readMaybe $ T.unpack $ T.filter (/= '.') celsiusText
                  in s == stationName && (Just c) == maybeCelsius
               _ -> False
     it "Should correctly handle an invalid row" $ do
-      parser "Bogotá,12.0" `shouldBe` Nothing
-      parser ";12.0" `shouldBe` Nothing
-      parser "Tokyo;12" `shouldBe` Nothing
+      unsafeParse "Bogotá,12.0" `shouldBe` Nothing
+      unsafeParse "Bogotá;" `shouldBe` Nothing
+      (isJust $ unsafeParse ";12.0") `shouldBe` True -- false positive
+      (isJust $ unsafeParse "Tokyo;12") `shouldBe` True -- false positive
+      (isJust $ unsafeParse "Aukland;.2") `shouldBe` True -- false positive


### PR DESCRIPTION
# Overview

- Ditch fancy, custom monad `Parser` for a down 'n dirty parser all in the name of speed. 😢 💔

## Profiling

```sh
λ 1brc +RTS -s -RTS -f ../data/measurements-1000000000.txt >/dev/null
5,762,461,106,304 bytes allocated in the heap
 205,582,051,808 bytes copied during GC
  58,996,507,232 bytes maximum residency (5 sample(s))
  15,067,393,440 bytes maximum slop
          131605 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     1376972 colls,     0 par   42.942s  52.004s     0.0000s    0.0097s
  Gen  1         5 colls,     0 par   22.657s  110.837s     22.1673s    82.2114s

  INIT    time    0.001s  (  0.002s elapsed)
  MUT     time  808.201s  (798.025s elapsed)
  GC      time   65.599s  (162.841s elapsed)
  EXIT    time    1.824s  (  0.000s elapsed)
  Total   time  875.625s  (960.867s elapsed)

  %GC     time       0.0%  (0.0% elapsed)

  Alloc rate    7,129,985,616 bytes per MUT second

  Productivity  92.3% of total user, 83.1% of total elapsed
```