### PR TITLE
v5 use `ByteString` everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Memory: 64 GB
 |    2    | Add strictness and compiler flags for small performance improvements. Read file content lazily.                                                                                                                                        | 969.98 sec     |   9.00% | [00ddd57](https://github.com/rhoskal/1brc-haskell/commit/00ddd571360f5cd60e90b9a55ab8bb7ed8914f25) |
 |    3    | Replace `State` monad with `List.foldl'`                                                                                                                                                                                               | 970.47 sec     |  -0.05% | [75211bb](https://github.com/rhoskal/1brc-haskell/commit/75211bbd93afc3ec32f1661aa2e3b5b500b184bf) |
 |    4    | Ditch fancy, custom monad `Parser` for a down 'n dirty parser all in the name of speed. 😢                                                                                                                                             | 875.62 sec     |  10.28% | [e2df7f6](https://github.com/rhoskal/1brc-haskell/commit/e2df7f6b23a8518689ede3d458a734cc6f0db080) |
+|    5    | Parser, formatter and printer all use `ByteString`.                                                                                                                                                                                    | 372.68 sec     |  80.58% |                                                                                                    |
 
 ## Development
 

--- a/benchmarks/Bench.hs
+++ b/benchmarks/Bench.hs
@@ -1,18 +1,14 @@
 import Criterion.Main
 import Parser
 import RIO
-import RIO.Text qualified as T
 import Summary
-
-parseLines :: [Text] -> [Maybe Observation]
-parseLines = map unsafeParse
 
 main :: IO ()
 main =
   defaultMain
     [ bgroup
         "Parser"
-        [ bench "unsafeParse 10_000_000" $ whnf parseLines $ gen 10000000
+        [ bench "unsafeParse" $ whnf unsafeParse "Belgium;12.9"
         ],
       bgroup
         "Summary"
@@ -20,6 +16,3 @@ main =
           bench "formatSummary" $ whnf formatSummary $ mkInitialSummary (Celsius 990)
         ]
     ]
-  where
-    gen :: Int -> [Text]
-    gen = T.lines . flip T.replicate "Belgium;12.9\n"

--- a/lib/Summary.hs
+++ b/lib/Summary.hs
@@ -8,7 +8,6 @@ where
 
 import Parser (Celsius (..))
 import RIO
-import RIO.Text qualified as T
 import Text.Printf
 
 data Summary = Summary
@@ -30,7 +29,7 @@ mergeSummary !s1 !s2 =
       !sCount' = sCount s1 + sCount s2
    in Summary sMin' sMax' sTotal' sCount'
 
-formatSummary :: Summary -> Text
+formatSummary :: Summary -> ByteString
 formatSummary !summary =
   let sMin' :: Double
       !sMin' = fromIntegral (sMin summary) / 10.0
@@ -40,4 +39,4 @@ formatSummary !summary =
 
       sMean' :: Double
       !sMean' = (fromIntegral (sTotal summary) / fromIntegral (sCount summary)) / 10.0
-   in T.pack $ printf "%.1f/%.1f/%.1f" sMin' sMean' sMax'
+   in fromString $ printf "%.1f/%.1f/%.1f" sMin' sMean' sMax'


### PR DESCRIPTION
# Overview

- Change parser, formatter and printer to use `ByteString` instead of `Text`
- Update tests and benchmarks

## Profiling

```sh
λ /usr/bin/time -h -p 1brc -f ../data/measurements-1000000000.txt >/dev/null
real 373.24
user 197.81
sys 42.60
```