### PR TITLE
v7 proper rounding

### DIFF
--- a/1brc.cabal
+++ b/1brc.cabal
@@ -179,6 +179,7 @@ test-suite 1brc-test
     -- Modules included in this executable, other than Main.
     other-modules:
         ParserSpec
+        SummarySpec
 
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Memory: 64 GB
 |    4    | Ditch fancy, custom monad `Parser` for a down 'n dirty parser all in the name of speed. 😢                                                                                                                                             | 875.62 sec     |  10.28% | [e2df7f6](https://github.com/rhoskal/1brc-haskell/commit/e2df7f6b23a8518689ede3d458a734cc6f0db080) |
 |    5    | Parser, formatter and printer all use `ByteString`.                                                                                                                                                                                    | 372.68 sec     |  80.58% | [35ac275](https://github.com/rhoskal/1brc-haskell/commit/35ac275d3895ec9700f5ee6040a2c5b47ea93dc8) |
 |    6    | Parse file in chunks.                                                                                                                                                                                                                  | 154.57 sec     |  82.73% | [35860b1](https://github.com/rhoskal/1brc-haskell/commit/35860b10b4603e1f9e688c983fc4fd768b0a1fd6) |
+|    7    | Proper floating point rounding.                                                                                                                                                                                                        | 155.14 sec     |   0.36% |                                                                                                    |
 
 ## Show & Tell
 
@@ -60,20 +61,20 @@ For more information, please visit https://1brc.dev
 
 ```sh
 λ 1brc -f ../data/measurements-10.txt -d
-2024-07-28 10:07:03.610839: [debug] Running v6...
-@(lib/Run.hs:78:3)
-2024-07-28 10:07:03.616891: [debug] First 10 processed:
-* (Station {unStation = "Alexandra"},Summary {sMin = 6, sMax = 6, sTotal = 6, sCount = 1})
-* (Station {unStation = "Benghazi"},Summary {sMin = 75, sMax = 75, sTotal = 75, sCount = 1})
-* (Station {unStation = "Blantyre"},Summary {sMin = 131, sMax = 131, sTotal = 131, sCount = 1})
-* (Station {unStation = "Bouak\195\169"},Summary {sMin = 163, sMax = 163, sTotal = 163, sCount = 1})
-* (Station {unStation = "Lyon"},Summary {sMin = 53, sMax = 53, sTotal = 53, sCount = 1})
-* (Station {unStation = "Napoli"},Summary {sMin = 213, sMax = 213, sTotal = 213, sCount = 1})
-* (Station {unStation = "Niamey"},Summary {sMin = 192, sMax = 192, sTotal = 192, sCount = 1})
-* (Station {unStation = "Port Vila"},Summary {sMin = 322, sMax = 322, sTotal = 322, sCount = 1})
-* (Station {unStation = "S\195\169gou"},Summary {sMin = 198, sMax = 198, sTotal = 198, sCount = 1})
-* (Station {unStation = "Vladivostok"},Summary {sMin = 155, sMax = 155, sTotal = 155, sCount = 1})
-@(lib/Run.hs:80:3)
+2024-07-30 19:58:03.149119: [debug] Running v7...
+@(lib/Run.hs:79:3)
+2024-07-30 19:58:03.156886: [debug] First 10 processed:
+* (Station {unStation = "Alexandra"},Summary {sMin = 0.6, sMax = 0.6, sTotal = 0.6, sCount = 1})
+* (Station {unStation = "Benghazi"},Summary {sMin = 7.5, sMax = 7.5, sTotal = 7.5, sCount = 1})
+* (Station {unStation = "Blantyre"},Summary {sMin = 13.1, sMax = 13.1, sTotal = 13.1, sCount = 1})
+* (Station {unStation = "Bouak\195\169"},Summary {sMin = 16.3, sMax = 16.3, sTotal = 16.3, sCount = 1})
+* (Station {unStation = "Lyon"},Summary {sMin = 5.3, sMax = 5.3, sTotal = 5.3, sCount = 1})
+* (Station {unStation = "Napoli"},Summary {sMin = 21.3, sMax = 21.3, sTotal = 21.3, sCount = 1})
+* (Station {unStation = "Niamey"},Summary {sMin = 19.2, sMax = 19.2, sTotal = 19.2, sCount = 1})
+* (Station {unStation = "Port Vila"},Summary {sMin = 32.2, sMax = 32.2, sTotal = 32.2, sCount = 1})
+* (Station {unStation = "S\195\169gou"},Summary {sMin = 19.8, sMax = 19.8, sTotal = 19.8, sCount = 1})
+* (Station {unStation = "Vladivostok"},Summary {sMin = 15.5, sMax = 15.5, sTotal = 15.5, sCount = 1})
+@(lib/Run.hs:83:3)
 {Alexandra=0.6/0.6/0.6, Benghazi=7.5/7.5/7.5, Blantyre=13.1/13.1/13.1, Bouaké=16.3/16.3/16.3, Lyon=5.3/5.3/5.3, Napoli=21.3/21.3/21.3, Niamey=19.2/19.2/19.2, Port Vila=32.2/32.2/32.2, Ségou=19.8/19.8/19.8, Vladivostok=15.5/15.5/15.5}
 ```
 

--- a/lib/Parser.hs
+++ b/lib/Parser.hs
@@ -12,7 +12,7 @@ import RIO.ByteString qualified as B
 newtype Station = Station {unStation :: ByteString}
   deriving (Eq, Ord, Show)
 
-newtype Celsius = Celsius {unCelsius :: Int16}
+newtype Celsius = Celsius {unCelsius :: Double}
   deriving (Eq, Ord, Show)
 
 data Observation = Observation
@@ -21,7 +21,7 @@ data Observation = Observation
   }
   deriving (Eq, Ord, Show)
 
-pCelsius :: ByteString -> Int16
+pCelsius :: ByteString -> Double
 pCelsius !input =
   -- c2w '-' == 45
   case B.index input 0 of
@@ -31,13 +31,13 @@ pCelsius !input =
       case B.index input 1 of
         46 ->
           let !c2 = B.index input 2
-           in (d2i c1 * 10) + d2i c2
+           in fromIntegral (d2i c1 * 10 + d2i c2) / 10.0
         !c2 ->
           let !c3 = B.index input 3
-           in (d2i c1 * 100) + (d2i c2 * 10) + d2i c3
+           in fromIntegral (d2i c1 * 100 + d2i c2 * 10 + d2i c3) / 10.0
   where
     -- c2w '0' == 48
-    d2i :: Word8 -> Int16
+    d2i :: Word8 -> Int
     d2i !c = fromIntegral c - 48
 
 unsafeParse :: ByteString -> Observation

--- a/lib/Run.hs
+++ b/lib/Run.hs
@@ -76,7 +76,7 @@ parseFile !filePath !chunkSize = do
 run :: RIO App ()
 run = do
   env <- ask
-  logDebug "Running v6..."
+  logDebug "Running v7..."
   let !filePath = aoInputFilePath $ view appOptionsL env
   let !chunkSize = aoChunkSize $ view appOptionsL env
   processed <- liftIO $ parseFile filePath chunkSize

--- a/lib/Summary.hs
+++ b/lib/Summary.hs
@@ -26,29 +26,23 @@ mergeSummary !s1 !s2 =
 -- | Mimic Java's `Math.round()`
 round' :: Double -> Double
 round' n =
-  let scaled :: Double
-      scaled = n * 10.0
+  let (intPart, fracPart) = properFraction (n * 10) :: (Int, Double)
 
-      r :: Double
-      r = fromIntegral (round scaled :: Int)
-
-      rounded :: Double
+      rounded :: Int
       rounded
-        | abs (r - scaled) == 0.5 =
-            if n < 0.0
-              then signum n * fromIntegral (floor (abs scaled) :: Int)
-              else signum n * fromIntegral (ceiling (abs scaled) :: Int)
-        | otherwise = fromIntegral (round scaled :: Int)
-   in rounded / 10.0
+        | fracPart == -0.5 = intPart
+        | fracPart == 0.5 = intPart + 1
+        | fracPart > 0 = if fracPart < 0.5 then intPart else intPart + 1
+        | fracPart < 0 = if fracPart > -0.5 then intPart else intPart - 1
+        | otherwise = intPart
+   in fromIntegral rounded / 10.0
 
 formatSummary :: Summary -> ByteString
 formatSummary (Summary !sMin' !sMax' !sTotal' !sCount') =
   B.concat
     [ fromString $ show $ round' sMin',
       "/",
-      fromString $ show $ (sTotal' / fromIntegral sCount'),
+      fromString $ show $ round' (sTotal' / fromIntegral sCount'),
       "/",
       fromString $ show $ round' sMax'
     ]
-
-

--- a/lib/Summary.hs
+++ b/lib/Summary.hs
@@ -42,7 +42,7 @@ formatSummary (Summary !sMin' !sMax' !sTotal' !sCount') =
   B.concat
     [ fromString $ show $ round' sMin',
       "/",
-      fromString $ show $ round' (sTotal' / fromIntegral sCount'),
+      fromString $ show $ round' (round' sTotal' / fromIntegral sCount'),
       "/",
       fromString $ show $ round' sMax'
     ]

--- a/lib/Summary.hs
+++ b/lib/Summary.hs
@@ -1,25 +1,19 @@
-module Summary
-  ( Summary,
-    formatSummary,
-    mergeSummary,
-    mkInitialSummary,
-  )
-where
+module Summary where
 
 import Parser (Celsius (..))
 import RIO
-import Text.Printf
+import RIO.ByteString qualified as B
 
 data Summary = Summary
-  { sMin :: {-# UNPACK #-} !Int16,
-    sMax :: {-# UNPACK #-} !Int16,
-    sTotal :: {-# UNPACK #-} !Int64,
+  { sMin :: {-# UNPACK #-} !Double,
+    sMax :: {-# UNPACK #-} !Double,
+    sTotal :: {-# UNPACK #-} !Double,
     sCount :: {-# UNPACK #-} !Int32
   }
   deriving (Show)
 
 mkInitialSummary :: Celsius -> Summary
-mkInitialSummary (Celsius !c) = Summary c c (fromIntegral c) 1
+mkInitialSummary (Celsius !c) = Summary c c c 1
 
 mergeSummary :: Summary -> Summary -> Summary
 mergeSummary !s1 !s2 =
@@ -29,14 +23,32 @@ mergeSummary !s1 !s2 =
       !sCount' = sCount s1 + sCount s2
    in Summary sMin' sMax' sTotal' sCount'
 
+-- | Mimic Java's `Math.round()`
+round' :: Double -> Double
+round' n =
+  let scaled :: Double
+      scaled = n * 10.0
+
+      r :: Double
+      r = fromIntegral (round scaled :: Int)
+
+      rounded :: Double
+      rounded
+        | abs (r - scaled) == 0.5 =
+            if n < 0.0
+              then signum n * fromIntegral (floor (abs scaled) :: Int)
+              else signum n * fromIntegral (ceiling (abs scaled) :: Int)
+        | otherwise = fromIntegral (round scaled :: Int)
+   in rounded / 10.0
+
 formatSummary :: Summary -> ByteString
-formatSummary !summary =
-  let sMin' :: Double
-      !sMin' = fromIntegral (sMin summary) / 10.0
+formatSummary (Summary !sMin' !sMax' !sTotal' !sCount') =
+  B.concat
+    [ fromString $ show $ round' sMin',
+      "/",
+      fromString $ show $ (sTotal' / fromIntegral sCount'),
+      "/",
+      fromString $ show $ round' sMax'
+    ]
 
-      sMax' :: Double
-      !sMax' = fromIntegral (sMax summary) / 10.0
 
-      sMean' :: Double
-      !sMean' = (fromIntegral (sTotal summary) / fromIntegral (sCount summary)) / 10.0
-   in fromString $ printf "%.1f/%.1f/%.1f" sMin' sMean' sMax'

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,6 @@ import SummarySpec (summarySpec)
 import Test.Hspec
 
 main :: IO ()
-main = hspec $ do
+main = hspec $ parallel $ do
   describe "Parser" parserSpec
   describe "Rounding" summarySpec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,9 @@
 import ParserSpec (parserSpec)
 import RIO
+import SummarySpec (summarySpec)
 import Test.Hspec
 
 main :: IO ()
-main = hspec parserSpec
+main = hspec $ do
+  describe "Parser" parserSpec
+  describe "Rounding" summarySpec

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -42,10 +42,10 @@ parserSpec = do
                 <> celsiusBS
 
             (Observation (Station s) (Celsius c)) = unsafeParse input
-         in (s == stationName) && fromString (show c) == B.filter (/= 46) celsiusBS
+         in (s == stationName) && fromString (show c) == celsiusBS
 
     it "Should correctly handle edge cases" $ do
       evaluate (unsafeParse "Buenos Aires,12.0") `shouldThrow` errorCall "no ';' found in \"Buenos Aires,12.0\""
       evaluate (unsafeParse "Tokyo;12") `shouldThrow` anyErrorCall
       evaluate (unsafeParse "Aukland;.2") `shouldThrow` anyErrorCall
-      unsafeParse ";12.0" `shouldBe` Observation (Station "") (Celsius 120)
+      unsafeParse ";12.0" `shouldBe` Observation (Station "") (Celsius 12.0)

--- a/test/SummarySpec.hs
+++ b/test/SummarySpec.hs
@@ -116,16 +116,16 @@ summarySpec = do
 
   describe "should handle others" $ do
     it "2.8499999999999996" $ do
-      round' (2.8499999999999996 :: Double) `shouldBe` (2.9 :: Double)
+      round' (2.8499999999999996 :: Double) `shouldBe` (2.8 :: Double)
     it "0.5499999999999998" $ do
-      round' (0.5499999999999998 :: Double) `shouldBe` (0.6 :: Double)
+      round' (0.5499999999999998 :: Double) `shouldBe` (0.5 :: Double)
     it "0.34999999999999987" $ do
-      round' (0.34999999999999987 :: Double) `shouldBe` (0.4 :: Double)
+      round' (0.34999999999999987 :: Double) `shouldBe` (0.3 :: Double)
     it "23.049999999999997" $ do
-      round' (23.049999999999997 :: Double) `shouldBe` (23.1 :: Double)
+      round' (23.049999999999997 :: Double) `shouldBe` (23.0 :: Double)
     it "25.549999999999997" $ do
-      round' (25.549999999999997 :: Double) `shouldBe` (25.6 :: Double)
+      round' (25.549999999999997 :: Double) `shouldBe` (25.5 :: Double)
     it "-1.0500000000000007" $ do
-      round' (-1.0500000000000007 :: Double) `shouldBe` (-1.0 :: Double)
+      round' (-1.0500000000000007 :: Double) `shouldBe` (-1.1 :: Double)
     it "11.649999999999999" $ do
-      round' (11.649999999999999 :: Double) `shouldBe` (11.7 :: Double)
+      round' (11.649999999999999 :: Double) `shouldBe` (11.6 :: Double)

--- a/test/SummarySpec.hs
+++ b/test/SummarySpec.hs
@@ -1,0 +1,131 @@
+module SummarySpec (summarySpec) where
+
+import RIO
+import Summary
+import Test.Hspec
+
+summarySpec :: Spec
+summarySpec = do
+  describe "should handle negative numbers" $ do
+    it "-0.00" $ do
+      round' (-0.00 :: Double) `shouldBe` (0.0 :: Double)
+    it "-0.01" $ do
+      round' (-0.01 :: Double) `shouldBe` (0.0 :: Double)
+    it "-0.02" $ do
+      round' (-0.02 :: Double) `shouldBe` (0.0 :: Double)
+    it "-0.03" $ do
+      round' (-0.03 :: Double) `shouldBe` (0.0 :: Double)
+    it "-0.04" $ do
+      round' (-0.04 :: Double) `shouldBe` (0.0 :: Double)
+    it "-0.05" $ do
+      round' (-0.05 :: Double) `shouldBe` (0.0 :: Double)
+    it "-0.06" $ do
+      round' (-0.06 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.07" $ do
+      round' (-0.07 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.08" $ do
+      round' (-0.08 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.09" $ do
+      round' (-0.09 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.10" $ do
+      round' (-0.10 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.11" $ do
+      round' (-0.11 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.12" $ do
+      round' (-0.12 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.13" $ do
+      round' (-0.13 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.14" $ do
+      round' (-0.14 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.15" $ do
+      round' (-0.15 :: Double) `shouldBe` (-0.1 :: Double)
+    it "-0.16" $ do
+      round' (-0.16 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.17" $ do
+      round' (-0.17 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.18" $ do
+      round' (-0.18 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.19" $ do
+      round' (-0.19 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.20" $ do
+      round' (-0.20 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.21" $ do
+      round' (-0.21 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.22" $ do
+      round' (-0.22 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.23" $ do
+      round' (-0.23 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.24" $ do
+      round' (-0.24 :: Double) `shouldBe` (-0.2 :: Double)
+    it "-0.25" $ do
+      round' (-0.25 :: Double) `shouldBe` (-0.2 :: Double)
+
+  describe "should handle positive numbers" $ do
+    it "0.00" $ do
+      round' (0.00 :: Double) `shouldBe` (0.0 :: Double)
+    it "0.01" $ do
+      round' (0.01 :: Double) `shouldBe` (0.0 :: Double)
+    it "0.02" $ do
+      round' (0.02 :: Double) `shouldBe` (0.0 :: Double)
+    it "0.03" $ do
+      round' (0.03 :: Double) `shouldBe` (0.0 :: Double)
+    it "0.04" $ do
+      round' (0.04 :: Double) `shouldBe` (0.0 :: Double)
+    it "0.05" $ do
+      round' (0.05 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.06" $ do
+      round' (0.06 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.07" $ do
+      round' (0.07 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.08" $ do
+      round' (0.08 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.09" $ do
+      round' (0.09 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.10" $ do
+      round' (0.10 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.11" $ do
+      round' (0.11 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.12" $ do
+      round' (0.12 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.13" $ do
+      round' (0.13 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.14" $ do
+      round' (0.14 :: Double) `shouldBe` (0.1 :: Double)
+    it "0.15" $ do
+      round' (0.15 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.16" $ do
+      round' (0.16 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.17" $ do
+      round' (0.17 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.18" $ do
+      round' (0.18 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.19" $ do
+      round' (0.19 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.20" $ do
+      round' (0.20 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.21" $ do
+      round' (0.21 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.22" $ do
+      round' (0.22 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.23" $ do
+      round' (0.23 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.24" $ do
+      round' (0.24 :: Double) `shouldBe` (0.2 :: Double)
+    it "0.25" $ do
+      round' (0.25 :: Double) `shouldBe` (0.3 :: Double)
+
+  describe "should handle others" $ do
+    it "2.8499999999999996" $ do
+      round' (2.8499999999999996 :: Double) `shouldBe` (2.9 :: Double)
+    it "0.5499999999999998" $ do
+      round' (0.5499999999999998 :: Double) `shouldBe` (0.6 :: Double)
+    it "0.34999999999999987" $ do
+      round' (0.34999999999999987 :: Double) `shouldBe` (0.4 :: Double)
+    it "23.049999999999997" $ do
+      round' (23.049999999999997 :: Double) `shouldBe` (23.1 :: Double)
+    it "25.549999999999997" $ do
+      round' (25.549999999999997 :: Double) `shouldBe` (25.6 :: Double)
+    it "-1.0500000000000007" $ do
+      round' (-1.0500000000000007 :: Double) `shouldBe` (-1.0 :: Double)
+    it "11.649999999999999" $ do
+      round' (11.649999999999999 :: Double) `shouldBe` (11.7 :: Double)

--- a/verify.lua
+++ b/verify.lua
@@ -1,108 +1,108 @@
 #!/usr/bin/env lua
 
 local file_names = {
-    "measurements-boundaries.txt",
-    "measurements-complex-utf8.txt",
-    "measurements-dot.txt",
-    "measurements-short.txt",
-    "measurements-shortest.txt",
-    "measurements-1.txt",
-    "measurements-10.txt",
-    "measurements-100.txt",
-    "measurements-1000.txt",
-    "measurements-10000.txt",
-    "measurements-100000.txt",
-    "measurements-1000000.txt",
-    "measurements-10000000.txt",
-    "measurements-100000000.txt",
-    "measurements-1000000000.txt"
+  "measurements-boundaries.txt",
+  "measurements-complex-utf8.txt",
+  "measurements-dot.txt",
+  "measurements-short.txt",
+  "measurements-shortest.txt",
+  "measurements-1.txt",
+  "measurements-10.txt",
+  "measurements-100.txt",
+  "measurements-1000.txt",
+  "measurements-10000.txt",
+  "measurements-100000.txt",
+  "measurements-1000000.txt",
+  "measurements-10000000.txt",
+  "measurements-100000000.txt",
+  "measurements-1000000000.txt"
 }
 
 local checksums = {
-    [1] = "9566eec019eb757ac5a711dcc1c2488eed27c296",  -- measurements-boundaries.out
-    [2] = "763658233b962178d350adfc6e194f4c22e25faa",  -- measurements-complex-utf8.out
-    [3] = "e25655bd5c7c12b11204f71f4c5c734dd0261c34",  -- measurements-dot.out
-    [4] = "209f51a7821315bb22f14f31ce3f41432a115c84",  -- measurements-short.out
-    [5] = "3a90bce85485a77b2fb9758e846dc64d07455d1e",  -- measurements-shortest.out
-    [6] = "1cee441d648c59b95387c925854607fdc293ffea",  -- measurements-1.out
-    [7] = "99cf6654daaeeab0aeb9c34935f408a1ba6d1734",  -- measurements-10.out
-    [8] = "3f8ac812e47ee6b153ab5e2fee1e2fcefd3521b2",  -- measurements-100.out
-    [9] = "af08d8e202ff8fa70605f93168016e5d2dd70550",  -- measurements-1000.out
-    [10] = "b7e371280f13e46a0dd32c519c1d113ad7ad95da", -- measurements-10000.out
-    [11] = "f682f944cc2113d87353d52f67399494c294c3dd", -- measurements-100000.out
-    [12] = "6d5fd0a864a2165450d26cc8949ee3c5ac934550", -- measurements-1000000.out
-    [13] = "c15afb6000715d76111c6c87f8fb9bd516f3b9d6", -- measurements-10000000.out
-    [14] = "6d4cf50c39fafd4068d71899839593761be2f796", -- measurements-100000000.out
-    [15] =
-    "92b9efa4eeab2ff9ecfb68fb4efdb341e36678bb"         -- measurements-1000000000.out
+  [1] = "9566eec019eb757ac5a711dcc1c2488eed27c296",    -- measurements-boundaries.out
+  [2] = "763658233b962178d350adfc6e194f4c22e25faa",    -- measurements-complex-utf8.out
+  [3] = "e25655bd5c7c12b11204f71f4c5c734dd0261c34",    -- measurements-dot.out
+  [4] = "209f51a7821315bb22f14f31ce3f41432a115c84",    -- measurements-short.out
+  [5] = "3a90bce85485a77b2fb9758e846dc64d07455d1e",    -- measurements-shortest.out
+  [6] = "1cee441d648c59b95387c925854607fdc293ffea",    -- measurements-1.out
+  [7] = "99cf6654daaeeab0aeb9c34935f408a1ba6d1734",    -- measurements-10.out
+  [8] = "3f8ac812e47ee6b153ab5e2fee1e2fcefd3521b2",    -- measurements-100.out
+  [9] = "af08d8e202ff8fa70605f93168016e5d2dd70550",    -- measurements-1000.out
+  [10] = "b7e371280f13e46a0dd32c519c1d113ad7ad95da",   -- measurements-10000.out
+  [11] = "f682f944cc2113d87353d52f67399494c294c3dd",   -- measurements-100000.out
+  [12] = "6d5fd0a864a2165450d26cc8949ee3c5ac934550",   -- measurements-1000000.out
+  [13] = "c15afb6000715d76111c6c87f8fb9bd516f3b9d6",   -- measurements-10000000.out
+  [14] = "6d4cf50c39fafd4068d71899839593761be2f796",   -- measurements-100000000.out
+  [15] =
+  "92b9efa4eeab2ff9ecfb68fb4efdb341e36678bb"           -- measurements-1000000000.out
 }
 
 local dir = arg[1]
 if not dir then
-    print("Usage: " .. arg[0] .. " <directory>")
-    os.exit(1)
+  print("Usage: " .. arg[0] .. " <directory>")
+  os.exit(1)
 end
 
 -- Ensure the provided argument is a directory
 local handle = io.popen("test -d '" .. dir .. "' && echo 'true' || echo 'false'")
 if not handle then
-    print("Error: Failed to open directory check handle.")
-    os.exit(1)
+  print("Error: Failed to open directory check handle.")
+  os.exit(1)
 end
 
 local result = handle:read("*a")
 if not result then
-    print("Error: Failed to read directory check result.")
-    handle:close()
-    os.exit(1)
+  print("Error: Failed to read directory check result.")
+  handle:close()
+  os.exit(1)
 end
 handle:close()
 
 result = result:gsub("%s+", "")
 if result ~= "true" then
-    print("Error: " .. dir .. " is not a directory.")
-    os.exit(1)
+  print("Error: " .. dir .. " is not a directory.")
+  os.exit(1)
 end
 
 for idx, file_name in ipairs(file_names) do
-    local file = dir .. "/" .. file_name
-    local key = file_name:match("measurements%-(.+)%..+")
+  local file = dir .. "/" .. file_name
+  local key = file_name:match("measurements%-(.+)%..+")
 
-    print("Verifying checksums: " .. file)
+  print("Verifying checksums: " .. file)
 
-    local file_handle = io.open(file, "r")
-    if file_handle then
-        file_handle:close()
+  local file_handle = io.open(file, "r")
+  if file_handle then
+    file_handle:close()
 
-        os.execute("1brc -f '" .. file .. "' > a.out")
+    os.execute("1brc -f '" .. file .. "' > a.out")
 
-        local hash_handle = io.popen("shasum a.out")
-        if not hash_handle then
-            print("Error: Failed to open hash computation handle.")
-            os.exit(1)
-        end
-
-        local hash_result = hash_handle:read("*a")
-        hash_handle:close()
-
-        if not hash_result then
-            print("Error: Failed to read hash computation result.")
-            os.exit(1)
-        end
-
-        local calculated_hash = hash_result:match("^(%S+)")
-        local expected_hash = checksums[idx]
-
-        if calculated_hash ~= expected_hash then
-            print("💥")
-            print("Expected: " .. expected_hash)
-            print("Received: " .. calculated_hash)
-            os.execute("rm a.out")
-            os.exit(1)
-        end
-    else
-        print("File " .. file .. " does not exist.")
+    local hash_handle = io.popen("shasum a.out")
+    if not hash_handle then
+      print("Error: Failed to open hash computation handle.")
+      os.exit(1)
     end
+
+    local hash_result = hash_handle:read("*a")
+    hash_handle:close()
+
+    if not hash_result then
+      print("Error: Failed to read hash computation result.")
+      os.exit(1)
+    end
+
+    local calculated_hash = hash_result:match("^(%S+)")
+    local expected_hash = checksums[idx]
+
+    if calculated_hash ~= expected_hash then
+      print("💥")
+      print("Expected: " .. expected_hash)
+      print("Received: " .. calculated_hash)
+      os.execute("rm a.out")
+      os.exit(1)
+    end
+  else
+    print("File " .. file .. " does not exist.")
+  end
 end
 
 os.execute("rm a.out")


### PR DESCRIPTION
# Overview

- Add proper floating point rounding based on Java's `Math.round()`. Not using `Fractional` since we don't need base 10 precision.
- Add a ton of tests to verify custom rounding function works as expected 

## Profiling 

```sh
λ /usr/bin/time -h -p 1brc -f ../data/measurements-1000000000.txt >/dev/null
real 155.14
user 152.67
sys 1.10
```